### PR TITLE
Replace nodemailer with resend for password reset emails

### DIFF
--- a/svelte-game-server/events/user/password/request-reset.js
+++ b/svelte-game-server/events/user/password/request-reset.js
@@ -1,14 +1,12 @@
-import nodemailer from 'nodemailer';
+import { Resend } from 'resend';
 import hashids from 'hashids';
 import { validateEmail } from '../../../helpers';
 
-const { SUPPORT_EMAIL_PASSWORD, PASSWORD_RESET_HASH } = process.env;
+const { RESEND_API_KEY, PASSWORD_RESET_HASH } = process.env;
 
 const Hashids = new hashids(PASSWORD_RESET_HASH);
 
 export default async ({ email, url }, { mongo }) => {
-  throw Error('Error feature not implemented');
-
   const collection = mongo.collection('users');
 
   const LCemail = email.toLowerCase().trim();
@@ -19,11 +17,9 @@ export default async ({ email, url }, { mongo }) => {
     email: LCemail
   });
 
-  // Check user exists
   // Return is equal to a success, so that the user can't fish for valid emails
   if (!user) return;
 
-  // Check if it's been more than 1 minute since last attempt
   // Return is equal to a success, so that the user can't fish for valid emails
   if (user.pwr > new Date().getTime()) return;
 
@@ -38,24 +34,14 @@ export default async ({ email, url }, { mongo }) => {
     }
   );
 
-  const transporter = nodemailer.createTransport({
-    host: 'mailcluster.loopia.se',
-    port: 587,
-    auth: {
-      user: 'noreply@worldseed.eu',
-      pass: SUPPORT_EMAIL_PASSWORD
-    }
-  });
-
   try {
     const token = Hashids.encode(pwr);
-    const result = await transporter.sendMail({
-      from: '"Ape Egg" <noreply@apeegg.com>',
+    await new Resend(RESEND_API_KEY).emails.send({
+      from: 'noreply@worldseed.eu',
       to: email,
       subject: 'Generic game password reset request',
-      text: `Hello ${user.email}!\n\nHere is your link to reset your password:\n${url}/reset-password/${token}\nThe link expires in 10 minutes.\n\nYou can't reply to this email.`
+      html: `<p>Hello ${user.email}!</p><p>Here is your link to reset your password:<br>${url}/reset-password/${token}<br>The link expires in 10 minutes.</p><p>You can't reply to this email.</p>`
     });
-    console.info(result);
   } catch (e) {
     console.error(e);
     throw Error('Failed to send mail');

--- a/svelte-game-server/package.json
+++ b/svelte-game-server/package.json
@@ -22,6 +22,6 @@
     "async-await-websockets": "^3.0.3",
     "hashids": "^2.3.0",
     "mongodb": "^4.8.1",
-    "nodemailer": "^6.9.15"
+    "resend": "^6.9.3"
   }
 }


### PR DESCRIPTION
## Summary
- Replace `nodemailer` dependency with `resend` (^6.9.3) in svelte-game-server
- Rewrite password reset email handler to use Resend API instead of Nodemailer SMTP transport
- Remove the `throw Error` that was disabling the password reset feature
- Uses `RESEND_API_KEY` env var and sends from `noreply@worldseed.eu`

## Test plan
- [ ] Add `RESEND_API_KEY` to the server `.env` file
- [ ] Run `bun install` in `svelte-game-server/` to install resend
- [ ] Trigger a password reset request and verify email is received
- [ ] Verify rate limiting still works (second request within 1 minute returns silently)
- [ ] Verify invalid/unknown emails don't leak information